### PR TITLE
v0.12.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,8 +51,16 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           rustup toolchain install stable --profile minimal
+          cargo install cargo-tarpaulin
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Run integration tests
         run: |
           cargo nextest run ${{ matrix.store }}_test
+          cargo tarpaulin -olcov
+      - name: Upload coverage data to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cargo doc --all-features --no-deps
 
-  test-integration:
+  tests:
     needs: check
     runs-on: ubuntu-latest
 
@@ -55,4 +55,4 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Run integration tests
         run: |
-          cargo nextest run ${{ matrix.store }}_test --test test_integration
+          cargo nextest run ${{ matrix.store }}_test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # example sqlite dbs
 rusqlite-example.db
+
+# Coverage report
+lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+# 0.12.0
+
+- Update `tower-sessions` to `0.12.0` and implement `SessionStore::create`.
+- add unit tests from [maxcountryman/tower-sessions/memory-store](https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62)
+
 # 0.11.1-2
 
-- Update `rusqlite` to `0.31.0`
+- Update `rusqlite` to `0.31.0`.
 
 # 0.11.1
 
-- Update `tower-sessions` to `0.11.1`
+- Update `tower-sessions` to `0.11.1`.
 
 # 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update `tower-sessions` to `0.12.0` and implement `SessionStore::create`.
 - add unit tests from [maxcountryman/tower-sessions/memory-store](https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62)
+- report test coverage to codecov
 
 # 0.11.1-2
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ All contributions are welcome!
 Check out the [counter example](./rusqlite-store/examples/counter.rs). Run it with `cargo run --example counter`.
 
 ## 🧪 Tests
-The tests are copied from [tower-session-stores](https://github.com/maxcountryman/tower-sessions-stores). Run them with `cargo nextest run rusqlite_store_test --test test_integration`.
+This crate is covered by integration- and unit-tests.
+The integration tests are copied from [tower-session-stores](https://github.com/maxcountryman/tower-sessions-stores) and kept in the `tests` create. They can be run with `cargo nextest run rusqlite_store_tests --test test_integration`.
+
+The unit tests are copied from [maxcountryman/tower-sessions/memory-store](https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62) and located directly in `src/lib.rs`. They can be run with `cargo nextest run rusqlite_store_tests -p tower-sessions-rusqlite-store`.
+
+Run tests with `cargo nextest run rusqlite_store_tests`.
 
 ## 🦺 Disclaimer
 This is an unofficial fork of the original `tower-sessions-stores`. I'm relatively new to Rust and might have made stupid mistakes.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     (tokio-)rusqlite session store for <code>tower-sessions</code>.
 </p>
 
-[![tests](https://github.com/patte/tower-sessions-rusqlite-store/actions/workflows/rust.yml/badge.svg)](https://github.com/patte/tower-sessions-rusqlite-store/actions/workflows/rust.yml) [![crates.io](https://img.shields.io/crates/v/tower-sessions-rusqlite-store)](https://crates.io/crates/tower-sessions-rusqlite-store)
+[![tests](https://github.com/patte/tower-sessions-rusqlite-store/actions/workflows/rust.yml/badge.svg)](https://github.com/patte/tower-sessions-rusqlite-store/actions/workflows/rust.yml) [![crates.io](https://img.shields.io/crates/v/tower-sessions-rusqlite-store)](https://crates.io/crates/tower-sessions-rusqlite-store) [![codecov](https://codecov.io/gh/patte/tower-sessions-rusqlite-store/graph/badge.svg?token=FZIFCIHNMB)](https://codecov.io/gh/patte/tower-sessions-rusqlite-store)
 
 
 ## Overview
@@ -25,13 +25,13 @@ The integration tests are copied from [tower-session-stores](https://github.com/
 
 The unit tests are copied from [maxcountryman/tower-sessions/memory-store](https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62) and located directly in `src/lib.rs`. They can be run with `cargo nextest run rusqlite_store_tests -p tower-sessions-rusqlite-store`.
 
-Run tests with `cargo nextest run rusqlite_store_tests`.
+Run all tests with: `cargo nextest run rusqlite_store_tests`.
 
 ## 🦺 Disclaimer
 This is an unofficial fork of the original `tower-sessions-stores`. I'm relatively new to Rust and might have made stupid mistakes.
 
 ## 🙏 Credits
-All credits go to the original authors of `tower-sessions-stores` and `tower-sessions`.
+Most credits go to the original authors of `tower-sessions-stores` and `tower-sessions`.
 
 <!-- 📦 Release
 cargo publish --dry-run -p tower-sessions-rusqlite-store

--- a/rusqlite-store/Cargo.toml
+++ b/rusqlite-store/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tower-sessions-rusqlite-store"
 description = "(tokio-)rusqlite session store for `tower-sessions`."
-version = "0.11.1-2"
+version = "0.12.0"
 edition = "2021"
 authors = ["Patrick Recher <p@tte.io>", "Max Countryman <hello@maxcountryman.com>"]
 license = "MIT"
@@ -19,11 +19,11 @@ rusqlite = { version = "0.31.0" }
 tokio-rusqlite = "0.5.0"
 thiserror = "1.0.56"
 time = "0.3.31"
-tower-sessions-core = { version = "0.11.1", features = ["deletion-task"] }
+tower-sessions-core = { version = "0.12.0", features = ["deletion-task"] }
 
 [dev-dependencies]
 axum = "0.7.1"
-tower-sessions = "0.11.1"
+tower-sessions = "0.12.0"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-test = "0.4.3"
 serde = "1"

--- a/rusqlite-store/src/lib.rs
+++ b/rusqlite-store/src/lib.rs
@@ -12,7 +12,7 @@ use tower_sessions_core::{
 /// An error type for Rusqlite stores.
 #[derive(thiserror::Error, Debug)]
 pub enum RusqliteStoreError {
-    /// A variant to map `rusqlite` errors.
+    /// A variant to map `tokio_rusqlite` errors.
     #[error(transparent)]
     TokioRusqlite(#[from] tokio_rusqlite::Error),
 
@@ -101,6 +101,47 @@ impl RusqliteStore {
     }
 }
 
+fn id_exists_with_conn(
+    conn: &rusqlite::Connection,
+    table_name: &str,
+    id: &Id,
+) -> rusqlite::Result<bool> {
+    let query = format!(
+        r#"
+        select exists(select 1 from {} where id = ?1)
+        "#,
+        table_name
+    );
+    let mut stmt = conn.prepare(&query)?;
+    stmt.query_row(params![id.to_string()], |row| row.get(0))
+}
+
+fn save_with_conn(
+    conn: &rusqlite::Connection,
+    table_name: &str,
+    record: &Record,
+    record_data: &[u8],
+) -> rusqlite::Result<usize> {
+    let query = format!(
+        r#"
+        insert into {}
+            (id, data, expiry_date) values (?1, ?2, ?3)
+        on conflict(id) do update set
+            data = excluded.data,
+            expiry_date = excluded.expiry_date
+        "#,
+        table_name
+    );
+    conn.execute(
+        &query,
+        params![
+            record.id.to_string(),
+            record_data,
+            record.expiry_date.unix_timestamp()
+        ],
+    )
+}
+
 #[async_trait]
 impl ExpiredDeletion for RusqliteStore {
     async fn delete_expired(&self) -> session_store::Result<()> {
@@ -130,31 +171,59 @@ impl ExpiredDeletion for RusqliteStore {
 
 #[async_trait]
 impl SessionStore for RusqliteStore {
-    async fn save(&self, record: &Record) -> session_store::Result<()> {
+    async fn create(&self, record: &mut Record) -> session_store::Result<()> {
         let conn = self.conn.clone();
 
-        conn.call({
-            let table_name = self.table_name.clone();
-            let record_id = record.id.to_string();
-            let record_data = rmp_serde::to_vec(record).map_err(RusqliteStoreError::Encode)?;
-            let record_expiry = record.expiry_date;
+        let new_id = conn
+            .call({
+                let mut record = record.clone();
+                let table_name = self.table_name.clone();
 
+                move |conn| {
+                    let tx = conn.transaction()?;
+
+                    while id_exists_with_conn(&tx, &table_name, &record.id)? {
+                        record.id = Id::default();
+                    }
+
+                    let record_data = rmp_serde::to_vec(&record)
+                        .map_err(|e| tokio_rusqlite::Error::Other(Box::new(e)))?;
+
+                    save_with_conn(&tx, &table_name, &record, &record_data)?;
+
+                    tx.commit()?;
+
+                    Ok(record.id)
+                }
+            })
+            .await
+            // extract encode error in box
+            .map_err(|e| match e {
+                tokio_rusqlite::Error::Other(boxed_err) => {
+                    match boxed_err.downcast::<rmp_serde::encode::Error>() {
+                        Ok(encode_error) => RusqliteStoreError::Encode(*encode_error),
+                        Err(original_err) => RusqliteStoreError::TokioRusqlite(
+                            tokio_rusqlite::Error::Other(original_err),
+                        ),
+                    }
+                }
+                _ => RusqliteStoreError::TokioRusqlite(e.into()),
+            })?;
+
+        record.id = new_id;
+
+        Ok(())
+    }
+
+    async fn save(&self, record: &Record) -> session_store::Result<()> {
+        let conn = self.conn.clone();
+        let table_name = self.table_name.clone();
+        let record = record.clone();
+        let record_data = rmp_serde::to_vec(&record).map_err(RusqliteStoreError::Encode)?;
+
+        conn.call({
             move |conn| {
-                let query = format!(
-                    r#"
-                    insert into {}
-                    (id, data, expiry_date) values (?1, ?2, ?3)
-                    on conflict(id) do update set
-                    data = excluded.data,
-                    expiry_date = excluded.expiry_date
-                    "#,
-                    table_name
-                );
-                conn.execute(
-                    &query,
-                    params![record_id, record_data, record_expiry.unix_timestamp()],
-                )
-                .map_err(|e| e.into())
+                save_with_conn(&conn, &table_name, &record, &record_data).map_err(|e| e.into())
             }
         })
         .await
@@ -232,4 +301,100 @@ fn is_valid_table_name(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+// unit tests from https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62
+#[cfg(test)]
+mod rusqlite_store_tests {
+    use time::Duration;
+
+    use super::*;
+
+    async fn create_store() -> RusqliteStore {
+        let conn = Connection::open_in_memory().await.unwrap();
+        let store = RusqliteStore::new(conn);
+        store.migrate().await.unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn test_create() {
+        let store = create_store().await;
+        let mut record = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date: OffsetDateTime::now_utc() + Duration::minutes(30),
+        };
+        assert!(store.create(&mut record).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_save() {
+        let store = create_store().await;
+        let record = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date: OffsetDateTime::now_utc() + Duration::minutes(30),
+        };
+        assert!(store.save(&record).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_load() {
+        let store = create_store().await;
+        let mut record = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date: OffsetDateTime::now_utc() + Duration::minutes(30),
+        };
+        store.create(&mut record).await.unwrap();
+        let loaded_record = store.load(&record.id).await.unwrap();
+        assert_eq!(Some(record), loaded_record);
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let store = create_store().await;
+        let mut record = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date: OffsetDateTime::now_utc() + Duration::minutes(30),
+        };
+        store.create(&mut record).await.unwrap();
+        assert!(store.delete(&record.id).await.is_ok());
+        assert_eq!(None, store.load(&record.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_create_id_collision() {
+        let store = create_store().await;
+        let expiry_date = OffsetDateTime::now_utc() + Duration::minutes(30);
+        let mut record1 = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date,
+        };
+        let mut record2 = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date,
+        };
+        store.create(&mut record1).await.unwrap();
+        record2.id = record1.id; // Set the same ID for record2
+        store.create(&mut record2).await.unwrap();
+        assert_ne!(record1.id, record2.id); // IDs should be different
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired() {
+        let store = create_store().await;
+        let mut record = Record {
+            id: Default::default(),
+            data: Default::default(),
+            expiry_date: OffsetDateTime::now_utc() - Duration::minutes(30),
+        };
+        store.create(&mut record).await.unwrap();
+        store.delete_expired().await.unwrap();
+        assert_eq!(None, store.load(&record.id).await.unwrap());
+    }
 }

--- a/rusqlite-store/src/lib.rs
+++ b/rusqlite-store/src/lib.rs
@@ -207,7 +207,7 @@ impl SessionStore for RusqliteStore {
                         ),
                     }
                 }
-                _ => RusqliteStoreError::TokioRusqlite(e.into()),
+                _ => RusqliteStoreError::TokioRusqlite(e),
             })?;
 
         record.id = new_id;
@@ -223,7 +223,7 @@ impl SessionStore for RusqliteStore {
 
         conn.call({
             move |conn| {
-                save_with_conn(&conn, &table_name, &record, &record_data).map_err(|e| e.into())
+                save_with_conn(conn, &table_name, &record, &record_data).map_err(|e| e.into())
             }
         })
         .await

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ time = "0.3.30"
 tokio = { version = "1", features = ["full"] }
 tower = "0.4.13"
 tower-cookies = "0.10.0"
-tower-sessions = "0.11.1"
+tower-sessions = "0.12.0"
 tower-sessions-rusqlite-store = { path = "../rusqlite-store/" }
 
 [[test]]


### PR DESCRIPTION
- Update `tower-sessions` to `0.12.0` and implement `SessionStore::create` to avoid id collisions.
- add unit tests from [maxcountryman/tower-sessions/memory-store](https://github.com/maxcountryman/tower-sessions/blob/6ad8933b4f5e71f3202f0c1a28f194f3db5234c8/memory-store/src/lib.rs#L62)
- report test coverage to codecov