### PR TITLE
deps: bump dependencies (tower-sessions v0.13, tokio-rusqlite v0.6, rusqlite 0.32)

### DIFF
--- a/rusqlite-store/Cargo.toml
+++ b/rusqlite-store/Cargo.toml
@@ -13,19 +13,19 @@ documentation = "https://docs.rs/tower-sessions-rusqlite-store"
 readme = "../README.md"
 
 [dependencies]
-async-trait = "0.1.77"
-rmp-serde = "1.1.2"
-rusqlite = { version = "0.31.0" }
-tokio-rusqlite = "0.5.0"
-thiserror = "1.0.56"
-time = "0.3.31"
-tower-sessions-core = { version = "0.12.0", features = ["deletion-task"] }
+async-trait = "0.1.83"
+rmp-serde = "1.3.0"
+rusqlite = { version = "0.32.1" }
+tokio-rusqlite = "0.6.0"
+thiserror = "1.0.64"
+time = "0.3.36"
+tower-sessions-core = { version = "0.13.0", features = ["deletion-task"] }
 
 [dev-dependencies]
-axum = "0.7.1"
-tower-sessions = "0.12.0"
-tokio = { version = "1.32.0", features = ["full"] }
-tokio-test = "0.4.3"
+axum = "0.7.7"
+tower-sessions = "0.13.0"
+tokio = { version = "1.40.0", features = ["full"] }
+tokio-test = "0.4.4"
 serde = "1"
 
 [[example]]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -6,14 +6,14 @@ publish = false
 
 [dev-dependencies]
 axum = "0.7"
-http = "1.0"
+http = "1.1"
 http-body-util = "0.1"
-hyper = "1.0"
-time = "0.3.30"
+hyper = "1.4"
+time = "0.3.36"
 tokio = { version = "1", features = ["full"] }
-tower = "0.4.13"
+tower = "0.5.1"
 tower-cookies = "0.10.0"
-tower-sessions = "0.12.0"
+tower-sessions = "0.13.0"
 tower-sessions-rusqlite-store = { path = "../rusqlite-store/" }
 
 [[test]]


### PR DESCRIPTION
tower-sessions-core "0.12.0" => "0.13.0"
tokio-rusqlite "0.5.0" => "0.6.0"
rusqlite "0.31.0" =>  "0.32.1"

async-trait "0.1.77" => "0.1.83"
rmp-serde "1.1.2" => "1.3.0"
thiserror "1.0.56" => "1.0.64"
time "0.3.31" => "0.3.36"

[dev-dependencies]
tower-sessions "0.12.0" => "0.13.0"
axum "0.7.1" => "0.7.7"
tokio "1.32.0" => "1.40.0"
tokio-test "0.4.3" => "0.4.4"