### PR TITLE
update tower-sessions (0.14.0) and axum (0.8) dependencies

### DIFF
--- a/rusqlite-store/Cargo.toml
+++ b/rusqlite-store/Cargo.toml
@@ -19,11 +19,11 @@ rusqlite = { version = "0.32.1" }
 tokio-rusqlite = "0.6.0"
 thiserror = "1.0.64"
 time = "0.3.36"
-tower-sessions-core = { version = "0.13.0", features = ["deletion-task"] }
+tower-sessions-core = { version = "0.14.0", features = ["deletion-task"] }
 
 [dev-dependencies]
-axum = "0.7.7"
-tower-sessions = "0.13.0"
+axum = "0.8" 
+tower-sessions = "0.14.0"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-test = "0.4.4"
 serde = "1"

--- a/rusqlite-store/src/lib.rs
+++ b/rusqlite-store/src/lib.rs
@@ -5,8 +5,7 @@ pub use tokio_rusqlite;
 use tokio_rusqlite::{params, Connection, Result as SqlResult};
 use tower_sessions_core::{
     session::{Id, Record},
-    session_store::{self, ExpiredDeletion},
-    SessionStore,
+    session_store, ExpiredDeletion, SessionStore,
 };
 
 /// An error type for Rusqlite stores.

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dev-dependencies]
-axum = "0.7"
+axum = "0.8"
 http = "1.1"
 http-body-util = "0.1"
 hyper = "1.4"
@@ -13,7 +13,7 @@ time = "0.3.36"
 tokio = { version = "1", features = ["full"] }
 tower = "0.5.1"
 tower-cookies = "0.10.0"
-tower-sessions = "0.13.0"
+tower-sessions = "0.14.0"
 tower-sessions-rusqlite-store = { path = "../rusqlite-store/" }
 
 [[test]]


### PR DESCRIPTION
Hi I tried using this session store while developing a project and ran into some compatibility issues since I was on `axum 0.8`. This updates the `axum` and `tower-sessions` dependencies