### PR TITLE
use bundled sqlite for examples and tests

### DIFF
--- a/rusqlite-store/Cargo.toml
+++ b/rusqlite-store/Cargo.toml
@@ -24,6 +24,7 @@ tower-sessions-core = { version = "0.13.0", features = ["deletion-task"] }
 [dev-dependencies]
 axum = "0.7.7"
 tower-sessions = "0.13.0"
+tokio-rusqlite = { version = "0.6.0", features=["bundled"] }
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-test = "0.4.4"
 serde = "1"

--- a/rusqlite-store/Cargo.toml
+++ b/rusqlite-store/Cargo.toml
@@ -24,7 +24,7 @@ tower-sessions-core = { version = "0.13.0", features = ["deletion-task"] }
 [dev-dependencies]
 axum = "0.7.7"
 tower-sessions = "0.13.0"
-tokio-rusqlite = { version = "0.6.0", features=["bundled"] }
+tokio-rusqlite = { version = "0.6.0", features = ["bundled"] }
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-test = "0.4.4"
 serde = "1"


### PR DESCRIPTION
Hi, in my previous PR while I was trying to test the updates, I ran into a linking error
```
LINK : fatal error LNK1181: cannot open input file 'sqlite3.lib'
``` 
probably because I'm developing on windows. I feel that adding the bundle feature would make testing with tests and examples a lot more seamless by removing the dependency on a system provided `sqlite` library.